### PR TITLE
Fix a typo and exclude VSCode settings from this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ cython_debug/
 env_file
 _log/
 .idea/
+
+.vscode

--- a/cctv/camera.py
+++ b/cctv/camera.py
@@ -95,7 +95,7 @@ class Camera(object):
             return f"http://{self.ip}/jpeg?id=2"
 
     def _raise_exception(self, message):
-        """Raise an exception after increassing exception_count"""
+        """Raise an exception after increasing exception_count"""
         self.exception_count + 1
         raise Exception(message)
 


### PR DESCRIPTION
## Contents

Nothing substantial here; just a typo fix and a setting to exclude vscode settings from getting in the repo.

## Intent

I'm cleaning up my ZenHub board and GitHub items that I have hanging out there.