### PR TITLE
Task for enabling & disabling cameras

### DIFF
--- a/cctv/camera.py
+++ b/cctv/camera.py
@@ -96,7 +96,7 @@ class Camera(object):
 
     def _raise_exception(self, message):
         """Raise an exception after increasing exception_count"""
-        self.exception_count + 1
+        self.exception_count += 1
         raise Exception(message)
 
     async def sleep(self):
@@ -104,6 +104,10 @@ class Camera(object):
 
     def is_disabled(self):
         return self.exception_count >= self.exception_limit
+
+    def disable_camera(self):
+        self.image = None
+        self.exception_count += self.exception_limit
 
     def _expiration_timestamp(self):
         """Formats an http-timestamp to be used in the `Expires` header. This header

--- a/cctv/camera.py
+++ b/cctv/camera.py
@@ -106,6 +106,9 @@ class Camera(object):
         return self.exception_count >= self.exception_limit
 
     def disable_camera(self):
+        """
+        Disables camera by increasing the exception count to the limit and removing any stored image.
+        """
         self.image = None
         self.exception_count += self.exception_limit
 

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -35,7 +35,9 @@ INITIAL_MAX_RANDOM_SLEEP = 300
 
 def get_camera_records(app, get_disabled=False):
     """Download camera records from Knack app.
-
+    Args:
+        app: knackpy app object
+        get_disabled: if True, return disabled camera records instead
     Returns:
         list: list of knackpy.Records
     """
@@ -82,9 +84,9 @@ def create_camera(record, fallback_img):
 
 
 async def worker(
-        camera: Camera,
-        session: httpx.AsyncClient,
-        boto_client: aiobotocore.session.AioSession,
+    camera: Camera,
+    session: httpx.AsyncClient,
+    boto_client: aiobotocore.session.AioSession,
 ):
     """Task-worker which manages i/o for a Camera instance. runs on an infinite loop until a
     camera becomes disabled, which happens if a camera upload/download fails repeatedly up
@@ -126,13 +128,19 @@ async def worker(
 
 async def update_camera_stack(app, cameras, session, boto_client):
     """
-    Checks Knack to see if the camera has been disabled by TPW staff.
+    Checks Knack to see if any cameras have been disabled or re-enabled by TPW staff.
+    Args:
+        app: knackpy app object
+        cameras: list of Camera objects
+        session (httpx.AsyncClient): The httpx session to use when fetching from cameras
+        boto_client (aiobotocore.session.AioSession): The (aio)boto3 session to upload images
     """
     fallback_img = load_fallback_img(FALLBACK_IMG_NAME)
     await asyncio.sleep(random.uniform(0, INITIAL_MAX_RANDOM_SLEEP))
     while True:
         logger.debug("Checking for disabled cameras from Knack...")
         cameras_knack = get_camera_records(app, get_disabled=True)
+        # Checking our published cameras to see if they were disabled
         for cam_data in cameras_knack:
             if cam_data.get(DISABLE_PUBLISH_FIELD):
                 cam_id = cam_data.get(ID_FIELD)
@@ -160,6 +168,7 @@ async def update_camera_stack(app, cameras, session, boto_client):
 
         await asyncio.sleep(SLEEP_SECONDS)
 
+
 def load_fallback_img(fname):
     dirname = os.path.dirname(__file__)
     filepath = os.path.join(dirname, fname)
@@ -186,10 +195,10 @@ async def main(timeout):
     session = aiobotocore.session.get_session()
 
     async with session.create_client(
-            "s3",
-            region_name="us-east-2",
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
+        "s3",
+        region_name="us-east-2",
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
     ) as boto_client:
         async with httpx.AsyncClient(timeout=timeout) as session:
             # create workers and tie them to tasks
@@ -197,7 +206,7 @@ async def main(timeout):
                 task_worker = worker(camera, session, boto_client)
                 task = asyncio.create_task(task_worker)
                 tasks.append(task)
-            # Task to check knack to see if any new cameras were disabled
+            # Task to check knack to see if any cameras were added or removed
             knack_worker = update_camera_stack(app, cameras, session, boto_client)
             knack_task = asyncio.create_task(knack_worker)
             tasks.append(knack_task)

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -139,7 +139,14 @@ async def update_camera_stack(app, cameras, session, boto_client):
     await asyncio.sleep(random.uniform(0, INITIAL_MAX_RANDOM_SLEEP))
     while True:
         logger.debug("Checking for disabled cameras from Knack...")
-        cameras_knack = get_camera_records(app, get_disabled=True)
+
+        try:
+            cameras_knack = get_camera_records(app, get_disabled=True)
+        except Exception as e:
+            logger.debug("Error trying to fetch camera data from Knack, skipping updating.")
+            await asyncio.sleep(SLEEP_SECONDS)
+            continue
+
         # Checking our published cameras to see if they were disabled
         for cam_data in cameras_knack:
             if cam_data.get(DISABLE_PUBLISH_FIELD):

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -140,10 +140,13 @@ async def update_camera_stack(app, cameras, session, boto_client):
     while True:
         logger.debug("Checking for disabled cameras from Knack...")
 
+        # getting disabled camera records from Knack
         try:
             cameras_knack = get_camera_records(app, get_disabled=True)
         except Exception as e:
+            # if we get an API error from Knack, just skip updating.
             logger.debug("Error trying to fetch camera data from Knack, skipping updating.")
+            logger.debug(e)
             await asyncio.sleep(SLEEP_SECONDS)
             continue
 
@@ -160,7 +163,15 @@ async def update_camera_stack(app, cameras, session, boto_client):
         cameras = [camera for camera in cameras if not camera.is_disabled()]
 
         # Now, check for cameras that were recently added or enabled
-        cameras_knack = get_camera_records(app, get_disabled=False)
+        try:
+            cameras_knack = get_camera_records(app, get_disabled=False)
+        except Exception as e:
+            # if we get an API error from Knack, just skip updating.
+            logger.debug("Error trying to fetch camera data from Knack, skipping updating.")
+            logger.debug(e)
+            await asyncio.sleep(SLEEP_SECONDS)
+            continue
+
         cam_ids = [camera.id for camera in cameras]
         for cam_data in cameras_knack:
             cam_id = cam_data.get(ID_FIELD)

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -13,6 +13,7 @@ import aiobotocore
 import knackpy
 
 from camera import Camera
+from camera import SLEEP_SECONDS
 
 # environment
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
@@ -32,24 +33,33 @@ TIMEOUT_DEFAULT = 180
 INITIAL_MAX_RANDOM_SLEEP = 300
 
 
-def get_camera_records():
+def get_camera_records(app, get_disabled=False):
     """Download camera records from Knack app.
 
     Returns:
         list: list of knackpy.Records
     """
-    logger.debug("Getting cameras from Knack...")
-    filters = {
-        "match": "and",
-        "rules": [
-            {"field": IP_FIELD, "operator": "is not blank"},
-            {"field": ID_FIELD, "operator": "is not blank"},
-            {"field": MODEL_FIELD, "operator": "is not blank"},
-            {"field": DISABLE_PUBLISH_FIELD, "operator": "is not", "value": True},
-        ],
-    }
-    app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
-    return app.get(KNACK_CONTAINER, filters=filters)
+
+    if get_disabled:
+        logger.debug("Fetching disabled cameras from Knack...")
+        filters = {
+            "match": "and",
+            "rules": [
+                {"field": DISABLE_PUBLISH_FIELD, "operator": "is", "value": True},
+            ],
+        }
+    else:
+        logger.debug("Fetching cameras from Knack...")
+        filters = {
+            "match": "and",
+            "rules": [
+                {"field": IP_FIELD, "operator": "is not blank"},
+                {"field": ID_FIELD, "operator": "is not blank"},
+                {"field": MODEL_FIELD, "operator": "is not blank"},
+                {"field": DISABLE_PUBLISH_FIELD, "operator": "is not", "value": True},
+            ],
+        }
+    return app.get(KNACK_CONTAINER, filters=filters, refresh=True)
 
 
 def create_camera(record, fallback_img):
@@ -72,9 +82,9 @@ def create_camera(record, fallback_img):
 
 
 async def worker(
-    camera: Camera,
-    session: httpx.AsyncClient,
-    boto_client: aiobotocore.session.AioSession,
+        camera: Camera,
+        session: httpx.AsyncClient,
+        boto_client: aiobotocore.session.AioSession,
 ):
     """Task-worker which manages i/o for a Camera instance. runs on an infinite loop until a
     camera becomes disabled, which happens if a camera upload/download fails repeatedly up
@@ -96,6 +106,8 @@ async def worker(
     while True:
         if camera.is_disabled():
             logger.debug(f"{camera.id} is disabled")
+            # overwrite stale image with placeholder
+            await camera.upload(boto_client)
             # terminate work if camera reaches disabled state
             return
         try:
@@ -110,6 +122,27 @@ async def worker(
             logger.error(f"Camera {camera.id}: upload: {str(e)}")
         # pause for sleep duration
         await camera.sleep()
+
+
+async def update_camera_stack(app, cameras):
+    """
+    Checks Knack to see if the camera has been disabled by TPW staff.
+    """
+    await asyncio.sleep(random.uniform(0, INITIAL_MAX_RANDOM_SLEEP))
+    while True:
+        logger.debug("Checking for disabled cameras from Knack...")
+        cameras_knack = get_camera_records(app, get_disabled=True)
+        for cam_data in cameras_knack:
+            if cam_data.get(DISABLE_PUBLISH_FIELD):
+                cam_id = cam_data.get(ID_FIELD)
+                for camera in cameras:
+                    if camera.id == cam_id:
+                        camera.disable_camera()
+                        logger.debug(f"Camera {cam_id} was disabled by Knack.")
+
+        # refreshing our list of cameras
+        cameras = [camera for camera in cameras if not camera.is_disabled()]
+        await asyncio.sleep(SLEEP_SECONDS)
 
 
 def load_fallback_img(fname):
@@ -128,7 +161,8 @@ async def main(timeout):
         timeout (int): The httpx session timeout (applied when downloading, not uploading images)
     """
     fallback_img = load_fallback_img(FALLBACK_IMG_NAME)
-    cameras_knack = get_camera_records()
+    app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
+    cameras_knack = get_camera_records(app)
     cameras = [create_camera(record, fallback_img) for record in cameras_knack]
     tasks = []
 
@@ -137,10 +171,10 @@ async def main(timeout):
     session = aiobotocore.session.get_session()
 
     async with session.create_client(
-        "s3",
-        region_name="us-east-2",
-        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        aws_access_key_id=AWS_ACCESS_KEY_ID,
+            "s3",
+            region_name="us-east-2",
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
     ) as boto_client:
         async with httpx.AsyncClient(timeout=timeout) as session:
             # create workers and tie them to tasks
@@ -148,6 +182,10 @@ async def main(timeout):
                 task_worker = worker(camera, session, boto_client)
                 task = asyncio.create_task(task_worker)
                 tasks.append(task)
+            # Task to check knack to see if any new cameras were disabled
+            knack_worker = update_camera_stack(app, cameras)
+            knack_task = asyncio.create_task(knack_worker)
+            tasks.append(knack_task)
             # Concurrently run all tasks until they complete
             await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -124,10 +124,11 @@ async def worker(
         await camera.sleep()
 
 
-async def update_camera_stack(app, cameras):
+async def update_camera_stack(app, cameras, session, boto_client):
     """
     Checks Knack to see if the camera has been disabled by TPW staff.
     """
+    fallback_img = load_fallback_img(FALLBACK_IMG_NAME)
     await asyncio.sleep(random.uniform(0, INITIAL_MAX_RANDOM_SLEEP))
     while True:
         logger.debug("Checking for disabled cameras from Knack...")
@@ -142,8 +143,22 @@ async def update_camera_stack(app, cameras):
 
         # refreshing our list of cameras
         cameras = [camera for camera in cameras if not camera.is_disabled()]
-        await asyncio.sleep(SLEEP_SECONDS)
 
+        # Now, check for cameras that were recently added or enabled
+        cameras_knack = get_camera_records(app, get_disabled=False)
+        cam_ids = [camera.id for camera in cameras]
+        for cam_data in cameras_knack:
+            cam_id = cam_data.get(ID_FIELD)
+            if cam_id not in cam_ids:
+                logger.debug(f"Camera {cam_id} was re-enabled by Knack.")
+                cam_obj = create_camera(cam_data, fallback_img)
+                cam_worker = worker(cam_obj, session, boto_client)
+                cam_task = asyncio.create_task(cam_worker)
+                event_loop = asyncio.get_event_loop()
+                asyncio.ensure_future(cam_task, loop=event_loop)
+                cameras.append(cam_obj)
+
+        await asyncio.sleep(SLEEP_SECONDS)
 
 def load_fallback_img(fname):
     dirname = os.path.dirname(__file__)
@@ -183,7 +198,7 @@ async def main(timeout):
                 task = asyncio.create_task(task_worker)
                 tasks.append(task)
             # Task to check knack to see if any new cameras were disabled
-            knack_worker = update_camera_stack(app, cameras)
+            knack_worker = update_camera_stack(app, cameras, session, boto_client)
             knack_task = asyncio.create_task(knack_worker)
             tasks.append(knack_task)
             # Concurrently run all tasks until they complete


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/16423

Adds a new async task to fetch camera records from knack every 5 minutes to check if AMD staff has disabled the camera's screenshots. It also checks for new cameras or cameras that have been reenabled to spin up new workers for those.

Testing this is pretty annoying to set up so I could set up some time to demo if you would prefer. 