### PR TITLE
Censored camera stored in a different state

### DIFF
--- a/cctv/camera.py
+++ b/cctv/camera.py
@@ -82,6 +82,7 @@ class Camera(object):
         self.is_fallback_uploaded = False
         self.url = self._build_url()
         self.exception_count = 0
+        self.censored_camera = False
 
     def _build_url(self):
         """Of the known camera models currently in use, type `advidia` has a distinct url
@@ -105,12 +106,15 @@ class Camera(object):
     def is_disabled(self):
         return self.exception_count >= self.exception_limit
 
-    def disable_camera(self):
+    def is_censored(self):
+        return self.censored_camera
+
+    def censor_camera(self):
         """
-        Disables camera by increasing the exception count to the limit and removing any stored image.
+        Disabled camera by the MMC via Knack API and removing any stored image.
         """
         self.image = None
-        self.exception_count += self.exception_limit
+        self.censored_camera = True
 
     def _expiration_timestamp(self):
         """Formats an http-timestamp to be used in the `Expires` header. This header

--- a/cctv/process_images.py
+++ b/cctv/process_images.py
@@ -106,7 +106,7 @@ async def worker(
     # apply an initial random sleep to avoid overloading CPU with concurrent i/o on init
     await asyncio.sleep(random.uniform(0, INITIAL_MAX_RANDOM_SLEEP))
     while True:
-        if camera.is_disabled():
+        if camera.is_disabled() or camera.is_censored():
             logger.debug(f"{camera.id} is disabled")
             # overwrite stale image with placeholder
             await camera.upload(boto_client)
@@ -156,11 +156,11 @@ async def update_camera_stack(app, cameras, session, boto_client):
                 cam_id = cam_data.get(ID_FIELD)
                 for camera in cameras:
                     if camera.id == cam_id:
-                        camera.disable_camera()
+                        camera.censor_camera()
                         logger.debug(f"Camera {cam_id} was disabled by Knack.")
 
         # refreshing our list of cameras
-        cameras = [camera for camera in cameras if not camera.is_disabled()]
+        cameras = [camera for camera in cameras if not camera.is_censored()]
 
         # Now, check for cameras that were recently added or enabled
         try:


### PR DESCRIPTION
@johnclary and I noticed during deploying this that I had an oversight in my last PR. When a cameras get disabled by the script for erroring out too many times, my update_camera_stack worker will rebuild that worker and then fail over and over again. We probably don't want to be sending these unavailable jpg's every 5 minutes to S3 for every camera that we cannot communicate with 💸

This fixes this by storing the "censored" cameras by the MMC in a separate variable from "disabled" cams that keep erroring out, usually due to COA fiber or device issues.

